### PR TITLE
Root pnpm workspace for web dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "stem-learning-platform",
+  "private": true,
+  "packageManager": "pnpm@10.28.2",
+  "scripts": {
+    "dev": "pnpm --dir web dev",
+    "build": "pnpm --dir web build",
+    "start": "pnpm --dir web start",
+    "lint": "pnpm --dir web lint"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "web"
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/web/README.md
+++ b/web/README.md
@@ -8,7 +8,13 @@ This is the Next.js application for the STEM Learning Platform.
 
 ## Setup
 1. Copy `web/.env.example` to `web/.env.local` and fill in keys.
-2. Run the dev server:
+2. From the repo root, install dependencies:
+
+```bash
+pnpm install
+```
+
+3. Run the dev server:
 
 ```bash
 pnpm dev


### PR DESCRIPTION
## Summary
- add root `pnpm-workspace.yaml` so `pnpm install` works from repo root
- add root `package.json` with helper scripts to run the web app
- update web README setup to install deps from root

## Motivation
Fixes editor/TypeScript errors like missing `next/link` and `react/jsx-runtime` by ensuring workspace installs dependencies correctly.

## Testing
- Not run (no network access in sandbox).