### PR TITLE
fix(build): align Next 16 server types

### DIFF
--- a/web/src/app/(auth)/login/page.test.tsx
+++ b/web/src/app/(auth)/login/page.test.tsx
@@ -2,8 +2,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 import LoginPage from "@/app/(auth)/login/page";
 
 describe("LoginPage", () => {
-  it("renders the login form", () => {
-    const html = renderToStaticMarkup(<LoginPage />);
+  it("renders the login form", async () => {
+    const html = renderToStaticMarkup(await LoginPage({}));
 
     expect(html).toContain("Welcome back");
     expect(html).toContain("Email");
@@ -11,17 +11,19 @@ describe("LoginPage", () => {
     expect(html).toContain("Sign in");
   });
 
-  it("shows verify notice when verify=1", () => {
+  it("shows verify notice when verify=1", async () => {
     const html = renderToStaticMarkup(
-      <LoginPage searchParams={{ verify: "1" }} />
+      await LoginPage({ searchParams: Promise.resolve({ verify: "1" }) })
     );
 
     expect(html).toContain("Check your email to verify your account");
   });
 
-  it("shows error message when provided", () => {
+  it("shows error message when provided", async () => {
     const html = renderToStaticMarkup(
-      <LoginPage searchParams={{ error: "Invalid login" }} />
+      await LoginPage({
+        searchParams: Promise.resolve({ error: "Invalid login" }),
+      })
     );
 
     expect(html).toContain("Invalid login");

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -6,14 +6,17 @@ type SearchParams = {
   verify?: string;
 };
 
-export default function LoginPage({
+export default async function LoginPage({
   searchParams,
 }: {
-  searchParams?: SearchParams;
+  searchParams?: Promise<SearchParams>;
 }) {
+  const resolvedSearchParams = await searchParams;
   const errorMessage =
-    typeof searchParams?.error === "string" ? searchParams.error : null;
-  const verify = searchParams?.verify === "1";
+    typeof resolvedSearchParams?.error === "string"
+      ? resolvedSearchParams.error
+      : null;
+  const verify = resolvedSearchParams?.verify === "1";
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">

--- a/web/src/app/(auth)/register/page.test.tsx
+++ b/web/src/app/(auth)/register/page.test.tsx
@@ -2,8 +2,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 import RegisterPage from "@/app/(auth)/register/page";
 
 describe("RegisterPage", () => {
-  it("renders the registration form", () => {
-    const html = renderToStaticMarkup(<RegisterPage />);
+  it("renders the registration form", async () => {
+    const html = renderToStaticMarkup(await RegisterPage({}));
 
     expect(html).toContain("Create an account");
     expect(html).toContain("Email");
@@ -11,9 +11,11 @@ describe("RegisterPage", () => {
     expect(html).toContain("Create account");
   });
 
-  it("shows error message when provided", () => {
+  it("shows error message when provided", async () => {
     const html = renderToStaticMarkup(
-      <RegisterPage searchParams={{ error: "Email already used" }} />
+      await RegisterPage({
+        searchParams: Promise.resolve({ error: "Email already used" }),
+      })
     );
 
     expect(html).toContain("Email already used");

--- a/web/src/app/(auth)/register/page.tsx
+++ b/web/src/app/(auth)/register/page.tsx
@@ -5,13 +5,16 @@ type SearchParams = {
   error?: string;
 };
 
-export default function RegisterPage({
+export default async function RegisterPage({
   searchParams,
 }: {
-  searchParams?: SearchParams;
+  searchParams?: Promise<SearchParams>;
 }) {
+  const resolvedSearchParams = await searchParams;
   const errorMessage =
-    typeof searchParams?.error === "string" ? searchParams.error : null;
+    typeof resolvedSearchParams?.error === "string"
+      ? resolvedSearchParams.error
+      : null;
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">

--- a/web/src/app/actions.ts
+++ b/web/src/app/actions.ts
@@ -15,7 +15,7 @@ export async function signIn(formData: FormData) {
   const email = getFormValue(formData, "email");
   const password = getFormValue(formData, "password");
 
-  const supabase = createServerSupabaseClient();
+  const supabase = await createServerSupabaseClient();
   const { error } = await supabase.auth.signInWithPassword({
     email,
     password,
@@ -32,7 +32,7 @@ export async function signUp(formData: FormData) {
   const email = getFormValue(formData, "email");
   const password = getFormValue(formData, "password");
 
-  const supabase = createServerSupabaseClient();
+  const supabase = await createServerSupabaseClient();
   const { error } = await supabase.auth.signUp({
     email,
     password,
@@ -46,7 +46,7 @@ export async function signUp(formData: FormData) {
 }
 
 export async function signOut() {
-  const supabase = createServerSupabaseClient();
+  const supabase = await createServerSupabaseClient();
   await supabase.auth.signOut();
   redirect("/login");
 }

--- a/web/src/app/classes/new/page.tsx
+++ b/web/src/app/classes/new/page.tsx
@@ -5,13 +5,16 @@ type SearchParams = {
   error?: string;
 };
 
-export default function NewClassPage({
+export default async function NewClassPage({
   searchParams,
 }: {
-  searchParams?: SearchParams;
+  searchParams?: Promise<SearchParams>;
 }) {
+  const resolvedSearchParams = await searchParams;
   const errorMessage =
-    typeof searchParams?.error === "string" ? searchParams.error : null;
+    typeof resolvedSearchParams?.error === "string"
+      ? resolvedSearchParams.error
+      : null;
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -3,8 +3,10 @@ import { redirect } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { signOut } from "@/app/actions";
 
+export const dynamic = "force-dynamic";
+
 export default async function DashboardPage() {
-  const supabase = createServerSupabaseClient();
+  const supabase = await createServerSupabaseClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/web/src/app/join/page.tsx
+++ b/web/src/app/join/page.tsx
@@ -5,13 +5,16 @@ type SearchParams = {
   error?: string;
 };
 
-export default function JoinClassPage({
+export default async function JoinClassPage({
   searchParams,
 }: {
-  searchParams?: SearchParams;
+  searchParams?: Promise<SearchParams>;
 }) {
+  const resolvedSearchParams = await searchParams;
   const errorMessage =
-    typeof searchParams?.error === "string" ? searchParams.error : null;
+    typeof resolvedSearchParams?.error === "string"
+      ? resolvedSearchParams.error
+      : null;
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">

--- a/web/src/lib/ai/blueprint.ts
+++ b/web/src/lib/ai/blueprint.ts
@@ -63,7 +63,7 @@ export function buildBlueprintPrompt(input: {
   return { system, user };
 }
 
-export function parseBlueprintResponse(raw: string) {
+export function parseBlueprintResponse(raw: string): BlueprintPayload {
   const jsonText = extractJson(raw);
   const parsed = JSON.parse(jsonText) as unknown;
   const validation = validateBlueprintPayload(parsed);
@@ -73,11 +73,11 @@ export function parseBlueprintResponse(raw: string) {
   return validation.value;
 }
 
-export function validateBlueprintPayload(payload: unknown): {
-  ok: boolean;
-  errors: string[];
-  value?: BlueprintPayload;
-} {
+export function validateBlueprintPayload(
+  payload: unknown
+):
+  | { ok: true; errors: string[]; value: BlueprintPayload }
+  | { ok: false; errors: string[] } {
   const errors: string[] = [];
 
   if (!payload || typeof payload !== "object") {

--- a/web/src/lib/supabase/server.ts
+++ b/web/src/lib/supabase/server.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
-export function createServerSupabaseClient() {
+export async function createServerSupabaseClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
@@ -9,7 +9,7 @@ export function createServerSupabaseClient() {
     throw new Error("Missing Supabase environment variables");
   }
 
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
 
   return createServerClient(url, anonKey, {
     cookies: {


### PR DESCRIPTION
## Summary
- Align App Router page props to Next 16 async `params`/`searchParams` expectations and adjust auth page tests.
- Make Supabase server client async and update call sites; tighten blueprint parsing types and add narrowing returns.
- Mark Supabase-backed pages as dynamic to avoid prerender errors during build.

## Testing
- Not run (build succeeded previously per user report).