### PR TITLE
fix: unblock class creation via RPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ build/
 
 # Misc
 *.tsbuildinfo
+
+# Supabase local CLI artifacts
+supabase/.branches/
+supabase/.temp/

--- a/supabase/migrations/0003_fix_rls_recursion.sql
+++ b/supabase/migrations/0003_fix_rls_recursion.sql
@@ -1,0 +1,57 @@
+-- Fix RLS recursion between classes and enrollments
+
+create or replace function is_class_owner(target_class_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  select exists (
+    select 1
+    from public.classes c
+    where c.id = target_class_id
+      and c.owner_id = auth.uid()
+  );
+$$;
+
+create or replace function is_class_member(target_class_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  select exists (
+    select 1
+    from public.classes c
+    where c.id = target_class_id
+      and c.owner_id = auth.uid()
+  ) or exists (
+    select 1
+    from public.enrollments e
+    where e.class_id = target_class_id
+      and e.user_id = auth.uid()
+  );
+$$;
+
+drop policy if exists classes_select_member on classes;
+create policy classes_select_member
+on classes for select
+using (is_class_member(id));
+
+drop policy if exists enrollments_select_member on enrollments;
+create policy enrollments_select_member
+on enrollments for select
+using (
+  auth.uid() = user_id
+  or is_class_owner(enrollments.class_id)
+);
+
+drop policy if exists enrollments_delete_self_or_owner on enrollments;
+create policy enrollments_delete_self_or_owner
+on enrollments for delete
+using (
+  auth.uid() = user_id
+  or is_class_owner(enrollments.class_id)
+);

--- a/supabase/migrations/0004_auth_context_helpers.sql
+++ b/supabase/migrations/0004_auth_context_helpers.sql
@@ -1,0 +1,120 @@
+-- Provide a per-request user id helper without touching auth schema.
+
+create or replace function public.requesting_user_id()
+returns uuid
+language sql
+volatile
+security definer
+set search_path = pg_catalog, public
+as $$
+  select coalesce(
+    nullif(current_setting('request.jwt.claim.sub', true), ''),
+    (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub')
+  )::uuid;
+$$;
+
+-- Use the helper in security-definer helpers to avoid cached auth.uid().
+create or replace function is_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  select exists (
+    select 1 from public.admin_users where user_id = public.requesting_user_id()
+  );
+$$;
+
+create or replace function is_class_owner(target_class_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  select exists (
+    select 1
+    from public.classes c
+    where c.id = target_class_id
+      and c.owner_id = public.requesting_user_id()
+  );
+$$;
+
+create or replace function is_class_member(target_class_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  select exists (
+    select 1
+    from public.classes c
+    where c.id = target_class_id
+      and c.owner_id = public.requesting_user_id()
+  ) or exists (
+    select 1
+    from public.enrollments e
+    where e.class_id = target_class_id
+      and e.user_id = public.requesting_user_id()
+  );
+$$;
+
+create or replace function join_class_by_code(code text)
+returns uuid
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  target_class_id uuid;
+  requester_id uuid;
+begin
+  requester_id := public.requesting_user_id();
+
+  if requester_id is null then
+    return null;
+  end if;
+
+  if code is null or length(trim(code)) = 0 then
+    return null;
+  end if;
+
+  select id into target_class_id
+  from public.classes
+  where upper(join_code) = upper(code)
+  limit 1;
+
+  if target_class_id is null then
+    return null;
+  end if;
+
+  insert into public.enrollments (class_id, user_id, role)
+  values (target_class_id, requester_id, 'student')
+  on conflict (class_id, user_id) do nothing;
+
+  return target_class_id;
+end;
+$$;
+
+-- Update insert/update/delete policies to use the helper directly.
+drop policy if exists classes_insert_owner on classes;
+create policy classes_insert_owner
+on classes for insert
+with check (public.requesting_user_id() = owner_id);
+
+drop policy if exists classes_update_owner on classes;
+create policy classes_update_owner
+on classes for update
+using (public.requesting_user_id() = owner_id);
+
+drop policy if exists classes_delete_owner on classes;
+create policy classes_delete_owner
+on classes for delete
+using (public.requesting_user_id() = owner_id);
+
+drop policy if exists enrollments_insert_self on enrollments;
+create policy enrollments_insert_self
+on enrollments for insert
+with check (public.requesting_user_id() = user_id);

--- a/supabase/migrations/0005_classes_owner_default.sql
+++ b/supabase/migrations/0005_classes_owner_default.sql
@@ -1,0 +1,4 @@
+-- Default class owner to the requesting user to avoid client-supplied owner_id.
+
+alter table public.classes
+  alter column owner_id set default public.requesting_user_id();

--- a/supabase/migrations/0006_classes_insert_policy.sql
+++ b/supabase/migrations/0006_classes_insert_policy.sql
@@ -1,0 +1,10 @@
+-- Allow any authenticated user to create a class while preventing owner spoofing.
+
+drop policy if exists classes_insert_owner on classes;
+create policy classes_insert_authenticated
+on classes for insert
+with check (public.requesting_user_id() is not null);
+
+-- Prevent clients from setting/changing ownership directly.
+revoke insert (owner_id) on public.classes from anon, authenticated;
+revoke update (owner_id) on public.classes from anon, authenticated;

--- a/supabase/migrations/0007_create_class_rpc.sql
+++ b/supabase/migrations/0007_create_class_rpc.sql
@@ -1,0 +1,32 @@
+-- Create class via security definer to avoid RLS insert issues.
+
+create or replace function public.create_class(
+  p_title text,
+  p_subject text,
+  p_level text,
+  p_description text,
+  p_join_code text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_user_id uuid;
+  v_class_id uuid;
+begin
+  v_user_id := public.requesting_user_id();
+  if v_user_id is null then
+    raise exception 'Not authenticated' using errcode = '42501';
+  end if;
+
+  insert into public.classes (owner_id, title, subject, level, description, join_code)
+  values (v_user_id, p_title, p_subject, p_level, p_description, p_join_code)
+  returning id into v_class_id;
+
+  return v_class_id;
+end;
+$$;
+
+grant execute on function public.create_class(text, text, text, text, text) to authenticated;

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -15,14 +15,13 @@ export async function middleware(request: NextRequest) {
 
   const supabase = createServerClient(url, anonKey, {
     cookies: {
-      get(name) {
-        return request.cookies.get(name)?.value;
+      getAll() {
+        return request.cookies.getAll();
       },
-      set(name, value, options) {
-        response.cookies.set({ name, value, ...options });
-      },
-      remove(name, options) {
-        response.cookies.set({ name, value: "", ...options });
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) => {
+          response.cookies.set({ name, value, ...options });
+        });
       },
     },
   });

--- a/web/src/app/api/debug/db-auth/route.ts
+++ b/web/src/app/api/debug/db-auth/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export async function GET() {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const supabase = await createServerSupabaseClient();
+  const { data, error } = await supabase.rpc("requesting_user_id");
+
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: error.message, code: error.code, details: error.details },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, requestingUserId: data });
+}

--- a/web/src/app/api/debug/insert-class/route.ts
+++ b/web/src/app/api/debug/insert-class/route.ts
@@ -1,0 +1,148 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+function randomJoinCode() {
+  return `DBG${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+}
+
+export async function GET() {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json(
+      { ok: false, error: userError?.message ?? "No user" },
+      { status: 401 },
+    );
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const {
+    data: requestingUserId,
+    error: requestingUserIdError,
+  } = await supabase.rpc("requesting_user_id");
+
+  const joinCode = randomJoinCode();
+  const { data, error } = await supabase.rpc("create_class", {
+    p_title: "Debug Class",
+    p_description: "Debug insert from /api/debug/insert-class",
+    p_subject: null,
+    p_level: null,
+    p_join_code: joinCode,
+  });
+
+  let directInsertResult: null | {
+    ok: boolean;
+    status: number;
+    error?: string;
+  } = null;
+  let directAuthContext: null | {
+    ok: boolean;
+    status: number;
+    data?: unknown;
+    error?: string;
+  } = null;
+  let directRequestingUserId: null | {
+    ok: boolean;
+    status: number;
+    data?: unknown;
+    error?: string;
+  } = null;
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (url && anonKey && session?.access_token) {
+    try {
+      const authRes = await fetch(`${url}/rest/v1/rpc/requesting_user_id`, {
+        method: "POST",
+        headers: {
+          apikey: anonKey,
+          Authorization: `Bearer ${session.access_token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+      if (!authRes.ok) {
+        const text = await authRes.text();
+        directAuthContext = { ok: false, status: authRes.status, error: text };
+      } else {
+        const json = await authRes.json();
+        directAuthContext = { ok: true, status: authRes.status, data: json };
+      }
+
+      directRequestingUserId = directAuthContext;
+
+      const res = await fetch(`${url}/rest/v1/classes?select=id`, {
+        method: "POST",
+        headers: {
+          apikey: anonKey,
+          Authorization: `Bearer ${session.access_token}`,
+          "Content-Type": "application/json",
+          Prefer: "return=representation, missing=default",
+        },
+        body: JSON.stringify({
+          title: "Debug Direct Insert",
+          description: "Debug insert via direct fetch",
+          join_code: randomJoinCode(),
+        }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        directInsertResult = { ok: false, status: res.status, error: text };
+      } else {
+        directInsertResult = { ok: true, status: res.status };
+      }
+    } catch (directError) {
+      directInsertResult = {
+        ok: false,
+        status: 0,
+        error:
+          directError instanceof Error ? directError.message : "Direct insert failed",
+      };
+    }
+  }
+
+  if (error || !data) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: error?.message ?? "Insert failed",
+        code: error?.code ?? null,
+        details: error?.details ?? null,
+        hint: error?.hint ?? null,
+        requestingUserId,
+        requestingUserIdError: requestingUserIdError?.message ?? null,
+        userId: user.id,
+        directInsertResult,
+        directAuthContext,
+        directRequestingUserId,
+      },
+      { status: 400 },
+    );
+  }
+
+  const { error: deleteError } = await supabase
+    .from("classes")
+    .delete()
+    .eq("id", data);
+
+  return NextResponse.json({
+    ok: true,
+    insertedId: data,
+    deleteError: deleteError?.message ?? null,
+    directInsertResult,
+    directAuthContext,
+    directRequestingUserId,
+  });
+}

--- a/web/src/app/api/debug/session/route.ts
+++ b/web/src/app/api/debug/session/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export async function GET() {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const cookieStore = await cookies();
+  const supabaseCookies = cookieStore
+    .getAll()
+    .filter((cookie) => cookie.name.startsWith("sb-"))
+    .map((cookie) => ({
+      name: cookie.name,
+      length: cookie.value.length,
+    }));
+
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+
+  type JwtClaims = {
+    sub?: string;
+    role?: string;
+    aud?: string | string[];
+    iss?: string;
+    exp?: number;
+    iat?: number;
+  };
+
+  let jwtClaims: JwtClaims | null = null;
+  if (session?.access_token) {
+    try {
+      const [, payload] = session.access_token.split(".");
+      if (payload) {
+        jwtClaims = JSON.parse(
+          Buffer.from(payload, "base64url").toString("utf8"),
+        ) as JwtClaims;
+      }
+    } catch {
+      jwtClaims = null;
+    }
+  }
+
+  return NextResponse.json({
+    userId: user?.id ?? null,
+    userEmail: user?.email ?? null,
+    userError: userError?.message ?? null,
+    sessionUserId: session?.user?.id ?? null,
+    hasAccessToken: Boolean(session?.access_token),
+    sessionError: sessionError?.message ?? null,
+    jwtSub: jwtClaims?.sub ?? null,
+    jwtRole: jwtClaims?.role ?? null,
+    jwtAud: jwtClaims?.aud ?? null,
+    jwtIss: jwtClaims?.iss ?? null,
+    jwtExp: jwtClaims?.exp ?? null,
+    jwtIat: jwtClaims?.iat ?? null,
+    cookieNames: supabaseCookies.map((cookie) => cookie.name),
+  });
+}

--- a/web/src/app/classes/actions.test.ts
+++ b/web/src/app/classes/actions.test.ts
@@ -144,10 +144,8 @@ describe("class actions", () => {
     supabaseAuth.getUser.mockResolvedValueOnce({ data: { user: { id: "u1" } } });
     vi.mocked(generateJoinCode).mockReturnValue("JOIN01");
 
+    supabaseRpcMock.mockResolvedValueOnce({ data: "class-1", error: null });
     supabaseFromMock.mockImplementation((table: string) => {
-      if (table === "classes") {
-        return makeInsertSequenceBuilder([{ data: { id: "class-1" }, error: null }]);
-      }
       if (table === "enrollments") {
         return makeBuilder({ error: null });
       }

--- a/web/src/app/classes/actions.ts
+++ b/web/src/app/classes/actions.ts
@@ -89,27 +89,27 @@ export async function createClass(formData: FormData) {
 
   for (let attempt = 0; attempt < MAX_JOIN_CODE_ATTEMPTS; attempt += 1) {
     const joinCode = generateJoinCode();
-    const { data, error } = await supabase
-      .from("classes")
-      .insert({
-        owner_id: user.id,
-        title,
-        description,
-        subject,
-        level,
-        join_code: joinCode,
-      })
-      .select("id")
-      .single();
+    const { data, error } = await supabase.rpc("create_class", {
+      p_title: title,
+      p_description: description ?? null,
+      p_subject: subject ?? null,
+      p_level: level ?? null,
+      p_join_code: joinCode,
+    });
 
     if (!error && data) {
-      newClassId = data.id;
+      newClassId = data;
       break;
     }
 
-    if (error?.code !== "23505") {
-      redirectWithError("/classes/new", error.message);
+    if (error) {
+      if (error.code !== "23505") {
+        redirectWithError("/classes/new", error.message);
+      }
+      continue;
     }
+
+    redirectWithError("/classes/new", "Unable to create class");
   }
 
   if (!newClassId) {

--- a/web/src/lib/supabase/server.ts
+++ b/web/src/lib/supabase/server.ts
@@ -13,14 +13,13 @@ export async function createServerSupabaseClient() {
 
   return createServerClient(url, anonKey, {
     cookies: {
-      get(name) {
-        return cookieStore.get(name)?.value;
+      getAll() {
+        return cookieStore.getAll();
       },
-      set(name, value, options) {
-        cookieStore.set({ name, value, ...options });
-      },
-      remove(name, options) {
-        cookieStore.set({ name, value: "", ...options });
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) => {
+          cookieStore.set({ name, value, ...options });
+        });
       },
     },
   });


### PR DESCRIPTION
## Summary
- add auth context helper (`requesting_user_id`) and update RLS helpers
- set `classes.owner_id` default and adjust insert policy; revoke client writes to owner_id
- add `create_class` security-definer RPC and use it in class creation
- update Supabase SSR cookie handling and add debug endpoints
- ignore Supabase local CLI artifacts

## Testing
- not run (manual: verified `/api/debug/insert-class` returns ok)
