### PR TITLE
[codex] fix supabase cookie write crash on home route

### DIFF
--- a/web/src/lib/supabase/server.ts
+++ b/web/src/lib/supabase/server.ts
@@ -19,7 +19,11 @@ export async function createServerSupabaseClient() {
       },
       setAll(cookiesToSet) {
         cookiesToSet.forEach(({ name, value, options }) => {
-          cookieStore.set({ name, value, ...options });
+          try {
+            cookieStore.set({ name, value, ...options });
+          } catch {
+            // Server Components cannot mutate cookies. Middleware handles refresh persistence.
+          }
         });
       },
     },


### PR DESCRIPTION
## Summary
This PR fixes a production server-side crash when loading the home page (`GET /`) on Vercel.

## User Impact
Users opening the app root URL saw the generic Next.js runtime error page instead of the landing experience. This blocked first-time entry and made the deployment appear down.

## Observed Production Error
From Vercel runtime logs on February 22, 2026:

- `Error: Cookies can only be modified in a Server Action or Route Handler`
- Triggered during `GET /`

## Root Cause
`createServerSupabaseClient()` in `web/src/lib/supabase/server.ts` attempted to call `cookieStore.set(...)` during Server Component rendering.

In Next.js App Router, cookie mutation is not allowed in this render context, so this threw at runtime and surfaced as a server-side exception.

## Fix
Updated Supabase server cookie handling in `web/src/lib/supabase/server.ts`:

- Keep `getAll()` behavior unchanged.
- Wrap `cookieStore.set(...)` in a `try/catch` inside `setAll(...)`.
- No-op cookie writes when running in Server Component render paths where mutation is disallowed.
- Added inline comment documenting why this is safe (middleware remains responsible for persistence paths).

## Why This Is Safe
This change only prevents illegal cookie mutation attempts in render-only contexts. It does not widen access, alter auth model, or change route authorization behavior.

## Validation
- `pnpm run lint` (passes)
- Manual production log correlation before/after code change (error path identified and addressed)

## Files Changed
- `web/src/lib/supabase/server.ts`