### PR TITLE
fix: increase maxTokens for blueprint generation to resolve JSON parsing errors

### DIFF
--- a/web/src/app/classes/[classId]/blueprint/actions.ts
+++ b/web/src/app/classes/[classId]/blueprint/actions.ts
@@ -605,7 +605,7 @@ export async function generateBlueprint(classId: string) {
       system: prompt.system,
       user: prompt.user,
       temperature: 0.2,
-      maxTokens: 1600,
+      maxTokens: 8000,
     });
     usedProvider = result.provider;
 


### PR DESCRIPTION
## Summary
- Increased `maxTokens` from 1600 to 8000 for blueprint generation
- Fixes "No JSON object found in AI response" error when creating course outlines
- Allows AI to generate more detailed/comprehensive blueprints with multiple topics, objectives, and evidence

## Root Cause
The AI was returning incomplete/empty responses due to insufficient output tokens when generating complex course blueprints with large material context.

## Test plan
- [ ] Deploy to Vercel
- [ ] Upload course materials and generate blueprint
- [ ] Verify JSON is successfully parsed and blueprint is created
- [ ] Check that the generated blueprint contains detailed topics and objectives

🤖 Generated with [Claude Code](https://claude.com/claude-code)