### PR TITLE
[codex] Fix blueprint warning contrast and collapsed sidebar compact rail

### DIFF
--- a/web/src/app/classes/[classId]/blueprint/BlueprintEditor.tsx
+++ b/web/src/app/classes/[classId]/blueprint/BlueprintEditor.tsx
@@ -720,7 +720,7 @@ export function BlueprintEditor({
       </div>
 
       {warningMessage ? (
-        <div className="rounded-2xl border border-amber-400/40 bg-amber-400/10 px-4 py-3 text-xs text-amber-100">
+        <div className="rounded-2xl border border-amber-300 bg-amber-50 px-4 py-3 text-xs text-amber-800">
           {warningMessage}
         </div>
       ) : null}
@@ -1075,12 +1075,12 @@ export function BlueprintEditor({
               ) : topicMap.errorMessage ? (
                 <div className="space-y-2 text-sm text-amber-700">
                   <p>{topicMap.errorMessage}</p>
-                  <p className="text-xs text-amber-100">{dependencySummary}</p>
+                  <p className="text-xs text-amber-700">{dependencySummary}</p>
                 </div>
               ) : topicMap.hasCycle ? (
                 <div className="space-y-3 text-sm text-amber-700">
                   <p>Cycle detected in prerequisites. Fix the loop to view the map.</p>
-                  <ul className="list-disc pl-5 text-xs text-amber-100">
+                  <ul className="list-disc pl-5 text-xs text-amber-700">
                     {draft.topics.map((topic) => (
                       <li key={`cycle-${topic.clientId}`}>
                         {topic.title || "Untitled"} →

--- a/web/src/app/components/Sidebar.tsx
+++ b/web/src/app/components/Sidebar.tsx
@@ -193,7 +193,11 @@ export default function Sidebar({ accountType, userEmail, userDisplayName, class
       className="fixed left-0 top-0 z-50 flex h-screen flex-col border-r border-default bg-[var(--background)] transition-all duration-300"
       style={{ width: "var(--sidebar-width)" }}
     >
-      <div className="flex h-16 items-center justify-between border-b border-default px-4">
+      <div
+        className={`flex h-16 items-center border-b border-default px-4 ${
+          isCompact ? "justify-center" : "justify-between"
+        }`}
+      >
         {!isCompact && (
           <Link
             href={accountType === "teacher" ? "/teacher/dashboard" : "/student/dashboard"}
@@ -207,7 +211,7 @@ export default function Sidebar({ accountType, userEmail, userDisplayName, class
         )}
         <button
           onClick={() => setIsCollapsed((value) => !value)}
-          className="ui-motion-color flex h-10 w-10 items-center justify-center rounded-full border border-default bg-white text-ui-muted hover:border-accent hover:text-accent"
+          className="ui-motion-color flex h-10 w-10 items-center justify-center rounded-xl border border-default bg-white text-ui-muted hover:border-accent hover:text-accent"
           aria-label={isCompact ? "Expand sidebar" : "Collapse sidebar"}
           type="button"
         >
@@ -215,16 +219,25 @@ export default function Sidebar({ accountType, userEmail, userDisplayName, class
         </button>
       </div>
 
-      <nav className="flex-1 space-y-1 px-2 py-4">
+      <nav
+        className={`flex-1 py-4 ${
+          isCompact ? "flex flex-col items-center gap-2 px-0" : "space-y-1 px-2"
+        }`}
+      >
         {navItems.map((item) => (
           <Link
             key={item.label}
             href={item.href}
-            className={`ui-motion-color flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium ${
+            className={`ui-motion-color flex items-center text-sm font-medium ${
+              isCompact ? "h-10 w-10 justify-center rounded-xl border" : "gap-3 rounded-lg px-3 py-2.5"
+            } ${
               isActive(item.href)
                 ? "border border-accent bg-accent-soft text-accent"
-                : "text-ui-muted hover:bg-[var(--surface-muted)] hover:text-ui-primary"
+                : isCompact
+                  ? "border-transparent text-ui-muted hover:bg-[var(--surface-muted)] hover:text-ui-primary"
+                  : "text-ui-muted hover:bg-[var(--surface-muted)] hover:text-ui-primary"
             }`}
+            aria-label={isCompact ? item.label : undefined}
             title={isCompact ? item.label : undefined}
           >
             {item.icon}
@@ -282,8 +295,9 @@ export default function Sidebar({ accountType, userEmail, userDisplayName, class
         <form action={signOut} className={`mt-3 ${isCompact ? "flex justify-center" : ""}`}>
           <button
             type="submit"
-            className={`ui-motion-color flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-ui-muted hover:bg-rose-50 hover:text-rose-700 ${
-              isCompact ? "w-full" : ""
+            aria-label={isCompact ? "Sign out" : undefined}
+            className={`ui-motion-color flex items-center justify-center text-sm font-medium text-ui-muted hover:bg-rose-50 hover:text-rose-700 ${
+              isCompact ? "h-10 w-10 rounded-xl border border-transparent" : "gap-2 rounded-lg px-3 py-2"
             }`}
           >
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>


### PR DESCRIPTION
## Summary
This PR resolves two UI quality issues reported during manual QA on the blueprint and shell navigation experiences.

On the blueprint page, advisory messaging in the draft editor used very low-contrast amber text on a light background, making important warnings difficult to read. In the sidebar, the collapsed state visually behaved like a compressed full-width row layout, which created alignment artifacts and an inconsistent compact navigation experience.

## User Impact
Before this fix:
- Teachers could miss critical advisory text (especially the warning that creating a new draft archives the current blueprint).
- Collapsed navigation felt visually broken due to spacing and highlight treatment that did not fit icon-only mode.

After this fix:
- Warning/advisory content in the blueprint editor is clearly readable in light mode.
- Collapsed sidebar now behaves as a centered icon rail with stable compact geometry, clearer active state, and better affordances.

## Root Cause
- The blueprint editor warning styles used light amber text tokens (`text-amber-100`) on very light backgrounds.
- Sidebar compact mode reused mostly row-oriented spacing/classes intended for expanded navigation, so collapsed UI inherited mismatched layout semantics.

## What Changed
### Blueprint editor readability
- Updated the warning/advisory banner palette to accessible light-warning styling:
  - Border/background shifted to `border-amber-300 bg-amber-50`
  - Text shifted to `text-amber-800`
- Aligned related topic-map warning details/cycle details away from low-contrast `text-amber-100` to readable amber text.

Files:
- `web/src/app/classes/[classId]/blueprint/BlueprintEditor.tsx`

### Collapsed sidebar compact rail
- In compact mode, switched navigation to centered icon-rail behavior with fixed tile geometry.
- Kept active item emphasis while avoiding stretched row artifacts in collapsed mode.
- Centered compact toggle/header behavior for cleaner alignment.
- Kept discoverability/accessibility with compact `title` and `aria-label` on icon-only nav items and compact sign-out.

Files:
- `web/src/app/components/Sidebar.tsx`

## Validation
Local checks run successfully in `web/`:
- `pnpm run lint`
- `pnpm test` (28 files, 163 tests passed)

Note: existing expected stderr output in blueprint action tests remained unchanged and did not affect pass/fail.

## Preview
- Vercel preview deployment: https://ai-stem-learning-platformgroup-8-296ya2md0.vercel.app

## Risk / Rollout Notes
- No data model, API, or server-action contract changes.
- Changes are limited to UI classes/markup in two client components.
- Expected risk is low and primarily visual; behavior regressions should be limited to compact sidebar rendering and blueprint warning presentation.