### PR TITLE
[codex] Fix low-contrast success banners across assignment workflows

### DIFF
--- a/web/src/app/classes/[classId]/activities/flashcards/[activityId]/edit/page.tsx
+++ b/web/src/app/classes/[classId]/activities/flashcards/[activityId]/edit/page.tsx
@@ -118,12 +118,12 @@ export default async function FlashcardsDraftEditPage({
           </div>
         ) : null}
         {savedMessage ? (
-          <div className="mb-6 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+          <div className="mb-6 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700">
             {savedMessage}
           </div>
         ) : null}
         {publishedMessage ? (
-          <div className="mb-6 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+          <div className="mb-6 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700">
             {publishedMessage}
           </div>
         ) : null}

--- a/web/src/app/classes/[classId]/activities/quiz/[activityId]/edit/page.tsx
+++ b/web/src/app/classes/[classId]/activities/quiz/[activityId]/edit/page.tsx
@@ -130,12 +130,12 @@ export default async function EditQuizDraftPage({
           </div>
         ) : null}
         {savedMessage ? (
-          <div className="mb-4 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+          <div className="mb-4 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700">
             {savedMessage}
           </div>
         ) : null}
         {publishedMessage ? (
-          <div className="mb-4 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+          <div className="mb-4 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700">
             {publishedMessage}
           </div>
         ) : null}

--- a/web/src/app/classes/[classId]/assignments/[assignmentId]/chat/page.tsx
+++ b/web/src/app/classes/[classId]/assignments/[assignmentId]/chat/page.tsx
@@ -163,7 +163,7 @@ export default async function AssignmentChatPage({
         ) : null}
 
         {submittedMessage ? (
-          <div className="mb-6 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+          <div className="mb-6 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700">
             {submittedMessage}
           </div>
         ) : null}

--- a/web/src/app/classes/[classId]/assignments/[assignmentId]/flashcards/FlashcardsAssignmentPanel.tsx
+++ b/web/src/app/classes/[classId]/assignments/[assignmentId]/flashcards/FlashcardsAssignmentPanel.tsx
@@ -56,7 +56,7 @@ export default function FlashcardsAssignmentPanel({
   return (
     <div className="space-y-6">
       {isSubmittedNotice ? (
-        <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+        <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700">
           Session submitted successfully.
         </div>
       ) : null}

--- a/web/src/app/classes/[classId]/assignments/[assignmentId]/quiz/QuizAssignmentPanel.tsx
+++ b/web/src/app/classes/[classId]/assignments/[assignmentId]/quiz/QuizAssignmentPanel.tsx
@@ -59,7 +59,7 @@ export default function QuizAssignmentPanel({
   return (
     <div className="space-y-6">
       {isSubmittedNotice ? (
-        <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+        <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700">
           Attempt submitted successfully.
         </div>
       ) : null}

--- a/web/src/app/classes/[classId]/assignments/[assignmentId]/review/page.tsx
+++ b/web/src/app/classes/[classId]/assignments/[assignmentId]/review/page.tsx
@@ -367,7 +367,7 @@ export default async function AssignmentReviewPage({
           </div>
         ) : null}
         {savedMessage ? (
-          <div className="mb-6 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+          <div className="mb-6 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700">
             {savedMessage}
           </div>
         ) : null}


### PR DESCRIPTION
## Summary
This PR fixes the low-contrast success-message regression reported in #46, where important confirmation text was hard to read after successful student/teacher actions.

## User Impact
Before this change, several success notices used `text-emerald-100` on `bg-emerald-500/10`. On many displays, the text appeared washed out and was easy to miss, which could make users think submissions or saves did not complete.

After this change, these banners use a stronger foreground color (`text-emerald-700`) while keeping the same container styling and layout, improving readability without changing interaction flow.

## Root Cause
Success banner variants were implemented in multiple screens with a very light text color intended for darker backgrounds, but the applied background was a very light translucent green.

## Changes
Updated success-banner text contrast in these files:
- `web/src/app/classes/[classId]/assignments/[assignmentId]/chat/page.tsx`
- `web/src/app/classes/[classId]/assignments/[assignmentId]/quiz/QuizAssignmentPanel.tsx`
- `web/src/app/classes/[classId]/assignments/[assignmentId]/flashcards/FlashcardsAssignmentPanel.tsx`
- `web/src/app/classes/[classId]/assignments/[assignmentId]/review/page.tsx`
- `web/src/app/classes/[classId]/activities/quiz/[activityId]/edit/page.tsx`
- `web/src/app/classes/[classId]/activities/flashcards/[activityId]/edit/page.tsx`

## Validation
- `npm run lint` (in `web/`): passed
- `npm run test` (in `web/`): passed

## Issue Link
Closes #46