### PR TITLE
[codex] Fix guest sandbox cleanup scheduling and re-entry handling

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-Last updated: 2026-04-05
+Last updated: 2026-04-07
 
 This runbook describes the hosted deployment topology for the current project. The platform is not just a single Vercel app with a database. It is a coordinated deployment across a frontend, a separate Python backend, and a Supabase project with Edge Functions and background jobs.
 
@@ -172,6 +172,7 @@ npx supabase functions deploy guest-sandbox-cleanup
 ```
 
 This function deletes expired or discarded guest sandbox data, associated storage objects, and anonymous auth users.
+It is intended to be invoked by a Supabase-native `pg_cron + pg_net` dispatch job rather than a Vercel cron.
 
 ## 4. Configure Supabase Edge Function Secrets
 
@@ -198,7 +199,8 @@ npx supabase secrets set MATERIAL_WORKER_TOKEN="<strong-random-token>"
 ### Required For `guest-sandbox-cleanup`
 
 - `GUEST_SANDBOX_CLEANUP_TOKEN`
-- `GUEST_SANDBOX_CLEANUP_BATCH` if you want to tune the default cleanup batch size
+- `GUEST_SANDBOX_CLEANUP_BATCH` if you want to tune the per-iteration cleanup batch size
+- `GUEST_SANDBOX_CLEANUP_MAX_TOTAL` if you want to cap total sandboxes deleted per invocation
 
 ### Important Secret Placement Notes
 
@@ -214,11 +216,42 @@ Create the Vault secrets in each hosted project:
 ```sql
 select vault.create_secret('https://<project-ref>.supabase.co', 'project_url');
 select vault.create_secret('<material-worker-token>', 'material_worker_token');
+select vault.create_secret('<guest-sandbox-cleanup-token>', 'guest_sandbox_cleanup_token');
 ```
 
 Use the SQL editor or an equivalent trusted workflow for this step.
 
-If you operationalize guest cleanup through SQL dispatch later, keep the same principle: project-level secrets belong in Supabase, not in the frontend deployment only.
+Guest cleanup now uses the same SQL-side dispatch principle as `material-worker`: project-level secrets belong in Supabase, not in the frontend deployment only.
+
+### Guest Cleanup Dispatch
+
+The guest cleanup scheduler is installed by the guest cleanup hardening migration and should appear in `cron.job` as:
+
+- `guest-sandbox-cleanup-dispatch-5m`
+
+It runs:
+
+```sql
+select public.run_guest_sandbox_cleanup_dispatch();
+```
+
+This SQL wrapper reads `project_url` and, when available, `guest_sandbox_cleanup_token` from Vault before POSTing to `/functions/v1/guest-sandbox-cleanup`.
+
+### Production Recovery After Deploy
+
+After deploying the migration and Edge Function:
+
+1. Verify `guest-sandbox-cleanup` is deployed.
+2. Verify the cron job `guest-sandbox-cleanup-dispatch-5m` exists.
+3. Manually invoke:
+
+```sql
+select public.run_guest_sandbox_cleanup_dispatch(100, 60000);
+select public.reconcile_guest_session_quota_service();
+```
+
+4. Repeat the dispatch until stale guest sandboxes are fully drained.
+5. Confirm `guest_session_quota.active_sessions` matches the count of truly active sandbox rows.
 
 ## 6. Deploy The Python Backend
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,6 +1,6 @@
 # Supabase Setup
 
-Last updated: 2026-04-05
+Last updated: 2026-04-07 22:27:51 HKT
 
 This directory contains the schema migrations, local Supabase configuration, and Edge Functions that support the STEM Learning Platform. Supabase is not just the database layer for this project. It also provides auth, storage, queue-backed background processing, guest sandbox lifecycle data, and Edge Function runtime support.
 
@@ -153,6 +153,7 @@ The hosted project should support the capabilities used by the migrations:
 - current defaults are 60 active guest sessions globally and 20 new guest sessions per hour
 - active sandboxes expire after 32 hours max or 8 hours of inactivity
 - cleanup removes guest class data and anonymous auth users
+- stale guest sessions are reconciled before new session cap checks so expired rows cannot block fresh guest entry indefinitely
 
 ## Current Guest Quota Model
 
@@ -162,6 +163,7 @@ The current guest quota model lives in `0023_guest_quota_redesign.sql`.
 - `acquire_guest_session_service` is called before sandbox creation and enforces the current active-session and hourly-creation caps
 - `release_guest_session_slot_service` is called when a session slot needs to be returned because provisioning failed or a sandbox timed out before frontend cleanup ran
 - `release_guest_sandbox_quota` and `guest-sandbox-cleanup` keep the AI and session counters aligned when expired or discarded sandboxes are deleted
+- `reconcile_guest_session_quota_service` marks stale active rows as expired and recomputes the global quota counters before the active-session cap is enforced
 
 ## Storage Notes
 
@@ -205,6 +207,12 @@ sequenceDiagram
 
 `guest-sandbox-cleanup` is responsible for cleaning expired or discarded guest sandboxes.
 
+Cleanup dispatch is now scheduled from Supabase itself, matching the material worker pattern:
+
+- SQL wrapper: `run_guest_sandbox_cleanup_dispatch`
+- cron job: `guest-sandbox-cleanup-dispatch-5m`
+- cadence: every 5 minutes
+
 ### Cleanup Responsibilities
 
 - find expired or discarded guest sandboxes
@@ -223,6 +231,7 @@ Set these in Supabase for the functions that need them:
 - `MATERIAL_WORKER_TOKEN`
 - `GUEST_SANDBOX_CLEANUP_TOKEN`
 - `GUEST_SANDBOX_CLEANUP_BATCH` if you need to tune the cleanup batch size
+- `GUEST_SANDBOX_CLEANUP_MAX_TOTAL` if you need to cap total deletions per invocation
 - provider API keys and model env vars for worker execution
 
 ### Vault Secrets
@@ -231,6 +240,7 @@ Material dispatch expects Vault secrets such as:
 
 - `project_url`
 - `material_worker_token`
+- `guest_sandbox_cleanup_token` when the cleanup Edge Function is protected by a bearer token
 
 These are used by SQL-side dispatch helpers and should be configured in each hosted environment.
 
@@ -258,6 +268,9 @@ npx supabase functions deploy guest-sandbox-cleanup
   - generate embeddings
   - update processing state
 - `guest-sandbox-cleanup`
+  - clean expired or discarded guest sandboxes
+  - release leaked quota counters and stale active-session counts
+  - run on a recurring Supabase cron schedule rather than an app-host cron
   - reclaim expired guest data
   - remove storage artifacts
   - delete anonymous users

--- a/supabase/functions/guest-sandbox-cleanup/index.ts
+++ b/supabase/functions/guest-sandbox-cleanup/index.ts
@@ -16,8 +16,9 @@ type GuestMaterialRow = {
 };
 
 const MATERIALS_BUCKET = "materials";
-const DEFAULT_BATCH_SIZE = Number(Deno.env.get("GUEST_SANDBOX_CLEANUP_BATCH") ?? "25");
+const DEFAULT_BATCH_SIZE = Number(Deno.env.get("GUEST_SANDBOX_CLEANUP_BATCH") ?? "100");
 const MAX_BATCH_SIZE = 100;
+const MAX_TOTAL_CLEANUP = Number(Deno.env.get("GUEST_SANDBOX_CLEANUP_MAX_TOTAL") ?? "500");
 const SEED_STORAGE_PREFIX = "guest-seed/";
 
 Deno.serve(async (req) => {
@@ -35,27 +36,51 @@ Deno.serve(async (req) => {
 
   const supabase = createServiceSupabaseClient();
   const batchSize = await resolveBatchSize(req);
-  const candidates = await listCleanupCandidates(supabase, batchSize);
-
+  let processed = 0;
   let cleaned = 0;
   const errors: string[] = [];
+  let lastBatchSize = 0;
 
-  for (const candidate of candidates) {
-    try {
-      await cleanupSandbox(supabase, candidate);
-      cleaned += 1;
-    } catch (error) {
-      errors.push(`${candidate.id}: ${error instanceof Error ? error.message : "Unknown cleanup failure."}`);
+  while (processed < MAX_TOTAL_CLEANUP) {
+    const remaining = MAX_TOTAL_CLEANUP - processed;
+    const candidates = await listCleanupCandidates(
+      supabase,
+      Math.min(batchSize, remaining),
+    );
+    lastBatchSize = candidates.length;
+
+    if (candidates.length === 0) {
+      break;
+    }
+
+    processed += candidates.length;
+
+    for (const candidate of candidates) {
+      try {
+        await cleanupSandbox(supabase, candidate);
+        cleaned += 1;
+      } catch (error) {
+        errors.push(`${candidate.id}: ${error instanceof Error ? error.message : "Unknown cleanup failure."}`);
+      }
+    }
+
+    if (candidates.length < batchSize) {
+      break;
     }
   }
+
+  const remainingCandidatesEstimate = await countCleanupCandidates(supabase);
 
   return json(
     {
       ok: true,
       requested_batch_size: batchSize,
-      processed: candidates.length,
+      processed,
       cleaned,
       failed: errors.length,
+      max_total_cleanup: MAX_TOTAL_CLEANUP,
+      hit_cleanup_cap: processed >= MAX_TOTAL_CLEANUP && lastBatchSize > 0,
+      remaining_candidates_estimate: remainingCandidatesEstimate,
       errors,
     },
     200,
@@ -95,18 +120,10 @@ async function resolveBatchSize(req: Request) {
 }
 
 async function listCleanupCandidates(supabase: SupabaseClient, batchSize: number) {
-  const expiryCutoff = new Date().toISOString();
-  const inactivityCutoff = new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString();
   const { data, error } = await supabase
     .from("guest_sandboxes")
     .select("id,user_id,status,active_ai_requests,created_at,expires_at,last_seen_at")
-    .or(
-      [
-        "status.in.(expired,discarded)",
-        `and(status.eq.active,expires_at.lte.${expiryCutoff})`,
-        `and(status.eq.active,last_seen_at.lte.${inactivityCutoff})`,
-      ].join(","),
-    )
+    .or(buildCleanupCandidateFilter())
     .order("expires_at", { ascending: true, nullsFirst: true })
     .order("last_seen_at", { ascending: true })
     .order("created_at", { ascending: true })
@@ -119,6 +136,30 @@ async function listCleanupCandidates(supabase: SupabaseClient, batchSize: number
   return ((data ?? []) as CleanupCandidate[]).filter(
     (candidate) => Boolean(candidate.id) && Boolean(candidate.user_id),
   );
+}
+
+async function countCleanupCandidates(supabase: SupabaseClient) {
+  const { count, error } = await supabase
+    .from("guest_sandboxes")
+    .select("id", { count: "exact", head: true })
+    .or(buildCleanupCandidateFilter());
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return count ?? 0;
+}
+
+function buildCleanupCandidateFilter() {
+  const expiryCutoff = new Date().toISOString();
+  const inactivityCutoff = new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString();
+
+  return [
+    "status.in.(expired,discarded)",
+    `and(status.eq.active,expires_at.lte.${expiryCutoff})`,
+    `and(status.eq.active,last_seen_at.lte.${inactivityCutoff})`,
+  ].join(",");
 }
 
 async function cleanupSandbox(supabase: SupabaseClient, candidate: CleanupCandidate) {

--- a/supabase/migrations/0025_guest_cleanup_scheduler_and_quota_reconciliation.sql
+++ b/supabase/migrations/0025_guest_cleanup_scheduler_and_quota_reconciliation.sql
@@ -1,0 +1,284 @@
+-- Schedule guest sandbox cleanup dispatch and reconcile stale quota state.
+
+create extension if not exists pg_net with schema extensions;
+create extension if not exists pg_cron;
+create extension if not exists vault with schema vault;
+
+create or replace function public.reconcile_guest_session_quota_service(
+  p_window_seconds integer default 3600
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_now timestamptz := now();
+  v_quota public.guest_session_quota%rowtype;
+  v_active_sessions integer := 0;
+  v_active_requests integer := 0;
+  v_expired_marked integer := 0;
+begin
+  if auth.role() is distinct from 'service_role' then
+    raise exception 'Service role is required.' using errcode = '42501';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtext('guest_session_quota'));
+
+  insert into public.guest_session_quota (scope)
+  values ('global')
+  on conflict (scope) do nothing;
+
+  update public.guest_sandboxes
+     set status = 'expired',
+         active_ai_requests = 0,
+         updated_at = v_now
+   where status = 'active'
+     and (
+       expires_at <= v_now
+       or last_seen_at <= v_now - interval '8 hours'
+     );
+  get diagnostics v_expired_marked = row_count;
+
+  update public.guest_sandboxes
+     set active_ai_requests = 0,
+         updated_at = v_now
+   where status in ('expired', 'discarded')
+     and greatest(coalesce(active_ai_requests, 0), 0) > 0;
+
+  select *
+    into v_quota
+    from public.guest_session_quota
+   where scope = 'global'
+   for update;
+
+  if extract(epoch from (v_now - v_quota.creation_window_started_at)) >
+     greatest(1, coalesce(p_window_seconds, 3600)) then
+    v_quota.creation_count := 0;
+    v_quota.creation_window_started_at := v_now;
+  end if;
+
+  select count(*)::integer,
+         coalesce(sum(greatest(coalesce(active_ai_requests, 0), 0)), 0)::integer
+    into v_active_sessions, v_active_requests
+    from public.guest_sandboxes
+   where status = 'active';
+
+  update public.guest_session_quota
+     set active_sessions = v_active_sessions,
+         active_requests = v_active_requests,
+         creation_count = v_quota.creation_count,
+         creation_window_started_at = v_quota.creation_window_started_at,
+         updated_at = v_now
+   where scope = 'global';
+
+  return jsonb_build_object(
+    'ok', true,
+    'expired_marked', v_expired_marked,
+    'active_sessions', v_active_sessions,
+    'active_requests', v_active_requests,
+    'creation_count', v_quota.creation_count,
+    'creation_window_started_at', v_quota.creation_window_started_at
+  );
+end;
+$$;
+
+revoke all on function public.reconcile_guest_session_quota_service(integer) from public;
+grant execute on function public.reconcile_guest_session_quota_service(integer) to service_role;
+
+create or replace function public.acquire_guest_session_service(
+  p_active_cap     integer default 60,
+  p_creation_cap   integer default 20,
+  p_window_seconds integer default 3600
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_quota public.guest_session_quota%rowtype;
+begin
+  if auth.role() is distinct from 'service_role' then
+    raise exception 'Service role is required.' using errcode = '42501';
+  end if;
+
+  perform public.reconcile_guest_session_quota_service(p_window_seconds);
+
+  select *
+    into v_quota
+    from public.guest_session_quota
+   where scope = 'global'
+   for update;
+
+  if v_quota.active_sessions >= p_active_cap then
+    return jsonb_build_object('ok', false, 'reason', 'cap_active');
+  end if;
+
+  if v_quota.creation_count >= p_creation_cap then
+    return jsonb_build_object('ok', false, 'reason', 'cap_creation');
+  end if;
+
+  update public.guest_session_quota
+     set active_sessions = v_quota.active_sessions + 1,
+         creation_count = v_quota.creation_count + 1,
+         creation_window_started_at = v_quota.creation_window_started_at,
+         updated_at = now()
+   where scope = 'global';
+
+  return jsonb_build_object('ok', true);
+end;
+$$;
+
+grant execute on function public.acquire_guest_session_service(integer, integer, integer) to service_role;
+
+create or replace function public.cleanup_expired_guest_sandboxes(
+  p_batch_size integer default 25
+)
+returns integer
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_row           record;
+  v_count         integer := 0;
+  v_limit         integer := greatest(1, least(coalesce(p_batch_size, 25), 100));
+  v_rows_affected integer := 0;
+  v_did_work      boolean;
+  v_released      integer := 0;
+begin
+  insert into public.guest_session_quota (scope)
+  values ('global')
+  on conflict (scope) do nothing;
+
+  for v_row in
+    select gs.id,
+           gs.user_id,
+           gs.status                                         as current_status,
+           greatest(coalesce(gs.active_ai_requests, 0), 0)  as active_ai_requests
+      from public.guest_sandboxes gs
+     where gs.status in ('expired', 'discarded')
+        or (
+          gs.status = 'active'
+          and (
+            gs.expires_at <= now()
+            or gs.last_seen_at <= now() - interval '8 hours'
+          )
+        )
+     order by gs.expires_at asc nulls first, gs.last_seen_at asc, gs.created_at asc
+     limit v_limit
+     for update skip locked
+  loop
+    v_did_work := false;
+    v_released := greatest(coalesce(v_row.active_ai_requests, 0), 0);
+
+    if v_released > 0 then
+      update public.guest_session_quota
+         set active_requests = greatest(active_requests - v_released, 0),
+             updated_at = now()
+       where scope = 'global';
+    end if;
+
+    -- Only rows that are still marked active should release an active-session slot.
+    if v_row.current_status = 'active' then
+      update public.guest_session_quota
+         set active_sessions = greatest(active_sessions - 1, 0),
+             updated_at = now()
+       where scope = 'global';
+    end if;
+
+    delete from public.classes where sandbox_id = v_row.id;
+    get diagnostics v_rows_affected = row_count;
+    if v_rows_affected > 0 then v_did_work := true; end if;
+
+    delete from auth.users where id = v_row.user_id and coalesce(is_anonymous, false);
+    get diagnostics v_rows_affected = row_count;
+    if v_rows_affected > 0 then v_did_work := true; end if;
+
+    delete from public.guest_sandboxes where id = v_row.id;
+    get diagnostics v_rows_affected = row_count;
+    if v_rows_affected > 0 then v_did_work := true; end if;
+
+    if v_did_work then v_count := v_count + 1; end if;
+  end loop;
+
+  return v_count;
+end;
+$$;
+
+grant execute on function public.cleanup_expired_guest_sandboxes(integer) to service_role;
+
+create or replace function public.run_guest_sandbox_cleanup_dispatch(
+  p_batch_size integer default 100,
+  p_timeout_milliseconds integer default 60000
+)
+returns bigint
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_project_url text;
+  v_cleanup_token text;
+  v_headers jsonb := jsonb_build_object('Content-Type', 'application/json');
+  v_request_id bigint;
+begin
+  select decrypted_secret
+    into v_project_url
+    from vault.decrypted_secrets
+   where name = 'project_url'
+   limit 1;
+
+  if v_project_url is null then
+    raise exception 'Missing vault secret: project_url';
+  end if;
+
+  select decrypted_secret
+    into v_cleanup_token
+    from vault.decrypted_secrets
+   where name = 'guest_sandbox_cleanup_token'
+   limit 1;
+
+  if v_cleanup_token is not null then
+    v_headers := v_headers || jsonb_build_object(
+      'Authorization',
+      'Bearer ' || v_cleanup_token
+    );
+  end if;
+
+  select net.http_post(
+    url := v_project_url || '/functions/v1/guest-sandbox-cleanup',
+    headers := v_headers,
+    body := jsonb_build_object(
+      'batchSize',
+      greatest(1, least(coalesce(p_batch_size, 100), 100))
+    ),
+    timeout_milliseconds := greatest(1000, coalesce(p_timeout_milliseconds, 60000))
+  )
+    into v_request_id;
+
+  return v_request_id;
+end;
+$$;
+
+revoke all on function public.run_guest_sandbox_cleanup_dispatch(integer, integer) from public;
+grant execute on function public.run_guest_sandbox_cleanup_dispatch(integer, integer) to postgres;
+
+do $$
+begin
+  if exists (
+    select 1
+      from cron.job
+     where jobname = 'guest-sandbox-cleanup-dispatch-5m'
+  ) then
+    perform cron.unschedule('guest-sandbox-cleanup-dispatch-5m');
+  end if;
+
+  perform cron.schedule(
+    'guest-sandbox-cleanup-dispatch-5m',
+    '5 minutes',
+    $job$select public.run_guest_sandbox_cleanup_dispatch();$job$
+  );
+end;
+$$;

--- a/web/src/lib/guest/sandbox.test.ts
+++ b/web/src/lib/guest/sandbox.test.ts
@@ -27,6 +27,8 @@ function makeMutableBuilder(result: { data?: unknown; error?: { message: string 
     insert: vi.fn().mockReturnThis(),
     update: vi.fn().mockReturnThis(),
     delete: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     maybeSingle: vi.fn().mockResolvedValue({
       data: result.data ?? null,
@@ -244,7 +246,7 @@ describe("provisionGuestSandbox", () => {
   });
 
   it("does not reuse an expired anonymous sandbox", async () => {
-    const { supabase } = mockSupabase({
+    const { supabase, adminRpcMock } = mockSupabase({
       auth: {
         getSession: vi.fn().mockResolvedValue({
           data: {
@@ -290,6 +292,8 @@ describe("provisionGuestSandbox", () => {
 
     expect(supabase.auth.signOut).toHaveBeenCalled();
     expect(supabase.auth.signInAnonymously).toHaveBeenCalled();
+    expect(adminRpcMock).toHaveBeenCalledWith("release_guest_session_slot_service", {});
+    expect(adminRpcMock).toHaveBeenCalledWith("acquire_guest_session_service", {});
     expect(result).toEqual({
       ok: true,
       classId: "class-1",
@@ -297,6 +301,61 @@ describe("provisionGuestSandbox", () => {
     });
 
     vi.useRealTimers();
+  });
+
+  it("rotates anonymous auth when the latest sandbox was already reconciled to expired", async () => {
+    let guestSandboxLookupCount = 0;
+    const { supabase } = mockSupabase({
+      auth: {
+        getSession: vi.fn().mockResolvedValue({
+          data: {
+            session: {
+              access_token: "guest-token",
+              user: { id: "anon-existing", is_anonymous: true },
+            },
+          },
+        }),
+        signInAnonymously: vi.fn().mockResolvedValue({
+          data: {
+            user: { id: "anon-new" },
+            session: { access_token: "guest-token-2" },
+          },
+          error: null,
+        }),
+        signOut: vi.fn().mockResolvedValue({ error: null }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "guest_sandboxes") {
+          guestSandboxLookupCount += 1;
+          if (guestSandboxLookupCount === 1) {
+            return makeMutableBuilder({ data: null });
+          }
+
+          return makeMutableBuilder({
+            data: {
+              id: "sandbox-expired",
+              class_id: "class-existing",
+              status: "expired",
+              guest_role: "teacher",
+              expires_at: "2026-03-26T23:59:59.000Z",
+              last_seen_at: "2026-03-27T00:00:00.000Z",
+              created_at: "2026-03-26T23:00:00.000Z",
+            },
+          });
+        }
+        return makeMutableBuilder({ data: null });
+      }),
+    });
+
+    const result = await provisionGuestSandbox();
+
+    expect(supabase.auth.signOut).toHaveBeenCalled();
+    expect(supabase.auth.signInAnonymously).toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: true,
+      classId: "class-1",
+      sandboxId: expect.any(String),
+    });
   });
 
   it("blocks guest provisioning when a real session already exists", async () => {

--- a/web/src/lib/guest/sandbox.ts
+++ b/web/src/lib/guest/sandbox.ts
@@ -70,6 +70,23 @@ function isAnonymousUser(user: {
   return user?.is_anonymous === true || user?.app_metadata?.provider === "anonymous";
 }
 
+async function loadLatestGuestSandbox(
+  supabase: Awaited<ReturnType<typeof createServerSupabaseClient>>,
+  userId: string,
+) {
+  return supabase
+    .from("guest_sandboxes")
+    .select("id,class_id,status,guest_role,expires_at,last_seen_at,created_at")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle<
+      ActiveSandboxRow & {
+        created_at?: string | null;
+      }
+    >();
+}
+
 /**
  * Marks a sandbox row as expired in place.
  *
@@ -251,6 +268,25 @@ export async function provisionGuestSandboxWithOptions(): Promise<GuestSandboxRe
       };
     }
 
+    let latestSandbox = existingSandbox;
+    if (!latestSandbox) {
+      const { data: latestSandboxData, error: latestSandboxError } = await loadLatestGuestSandbox(
+        supabase,
+        existingUser.id,
+      );
+
+      if (latestSandboxError && !isMaybeSingleNoRowsError(latestSandboxError)) {
+        return {
+          ok: false,
+          code: "guest-session-check-failed",
+          error: "We couldn't verify your current guest session. Please try again.",
+          reason: "latest-session-check",
+        };
+      }
+
+      latestSandbox = latestSandboxData ?? null;
+    }
+
     // --- Branch: expired sandbox ---
 
     if (existingSandbox && isGuestSandboxExpired(existingSandbox)) {
@@ -269,6 +305,24 @@ export async function provisionGuestSandboxWithOptions(): Promise<GuestSandboxRe
 
       // For an anonymous user the Auth record is only useful while the sandbox
       // is alive.  Sign them out so a fresh anonymous user can be created below.
+      await supabase.auth.signOut();
+      guestUserId = null;
+    }
+
+    // --- Branch: latest sandbox was already reconciled to a non-active state ---
+    // Reconciliation may mark the sandbox expired before the browser returns.
+    // Anonymous users must still rotate auth here so the cleanup worker deleting
+    // the old auth.users row cannot cascade a newly created sandbox away.
+    if (!existingSandbox && latestSandbox && latestSandbox.status !== "active") {
+      if (!existingUserIsAnonymous) {
+        return {
+          ok: false,
+          code: "guest-session-conflict",
+          error: getGuestSessionExpiredMessage(),
+          reason: "non-active-non-anonymous-session",
+        };
+      }
+
       await supabase.auth.signOut();
       guestUserId = null;
     }


### PR DESCRIPTION
## Summary
This PR hardens guest sandbox cleanup so stale guest sessions do not block new guest entry, and fixes the follow-up correctness issues uncovered during review.

## Problem
Guest mode was being denied with `too-many-active-sessions` because stale sandbox rows remained counted as active in production. The initial cleanup hardening approach also introduced two lifecycle risks:
- a reconciled expired sandbox could allow anonymous auth reuse, so later cleanup of the old auth user could cascade-delete a newly created sandbox
- stale `active_ai_requests` values could be removed twice, causing `guest_session_quota.active_requests` to drift below reality

## Changes
- add `0025_guest_cleanup_scheduler_and_quota_reconciliation.sql`
- schedule `guest-sandbox-cleanup` from Supabase with `pg_cron + pg_net`
- add quota reconciliation before guest-session cap checks
- zero stale per-row `active_ai_requests` during reconciliation to prevent double-release
- teach the guest web flow to detect the latest non-active sandbox for the current anonymous user and rotate auth before provisioning a fresh sandbox
- harden the cleanup Edge Function to drain backlogs in larger bounded batches
- update deployment and Supabase runbooks for the scheduler and recovery workflow

## Root Cause
The system relied on stale guest sandbox rows eventually being cleaned, but cleanup was not keeping pace with reality. Once the active-session quota row drifted high enough, guest entry failed. The first hardening pass corrected the counter too early at the SQL layer without updating the web re-entry lifecycle, which made anonymous-user reuse unsafe.

## Validation
- `pnpm --dir web exec vitest run src/lib/guest/sandbox.test.ts`
- `pnpm lint`
- verified the new regression test for a reconciled expired sandbox re-entry path

## Risks / Follow-up
- this PR does not apply the migration or run the production cleanup backfill; that still needs to be done separately with `supabase db push`
- production should be checked after rollout to confirm `guest_session_quota.active_sessions` matches true active sandbox rows and that the cleanup cron is installed